### PR TITLE
doc(README): Add note about mongodb connection and fastify.close

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,10 @@ mongodb.MongoClient.connect('mongodb://mongo/db')
   })
 ```
 
-Note: the passed `client` connection will **not** be closed when the Fastify server
+Notes: 
+* the passed `client` connection will **not** be closed when the Fastify server
 shuts down.
+* in order to terminate the mongodb connection you have to manually call the [fastify.close](https://www.fastify.io/docs/latest/Server/#close) method (for example for testing purposes, otherwise the test will hang).
 
 ## Reference
 


### PR DESCRIPTION
I'm not sure about the "terminate" word that could create confusion with the `forceClose` feature.  Let me know if you want me to change this.